### PR TITLE
Add custom urls for EU/Sandbox

### DIFF
--- a/conf/lamp.conf
+++ b/conf/lamp.conf
@@ -12,6 +12,10 @@ apiKey=your_api_key
 ##connectionTimeout=50
 ##requestTimeout=100
 
+############## Use alternative urls for connection to EU / Sandbox server############
+## opsgenie.api.url=https://api.eu.opsgenie.com
+## opsgenie.api.url=https://api.sandbox.opsgenie.com
+
 ############## Use following configuration options to configure logger ############
 lamp.log.level = warn
 lamp.log.file = lamp.log


### PR DESCRIPTION
In order to make it easier for EU/Sandbox users to understand how to configure, add example config in ``conf/lamp.conf``