### PR TITLE
Support for Schedules API

### DIFF
--- a/command/schedule_cmd.go
+++ b/command/schedule_cmd.go
@@ -1,0 +1,669 @@
+package command
+
+import (
+	"fmt"
+	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
+	"github.com/opsgenie/opsgenie-go-sdk-v2/schedule"
+	gcli "github.com/urfave/cli"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func NewScheduleClient(c *gcli.Context) *schedule.Client {
+	scheduleCli, cliErr := schedule.NewClient(getConfigurations(c))
+	if cliErr != nil {
+		message := "Can not create the schedule client. " + cliErr.Error()
+		fmt.Printf("%s\n", message)
+		os.Exit(1)
+	}
+	printVerboseMessage("Schedule Client created.")
+
+	return scheduleCli
+}
+
+func CreateScheduleAction(c *gcli.Context) {
+	cli := NewScheduleClient(c)
+	req := schedule.CreateRequest{}
+
+	if name, ok := getVal("name", c); ok {
+		req.Name = name
+	}
+	if description, ok := getVal("description", c); ok {
+		req.Description = description
+	}
+	if timezone, ok := getVal("tz", c); ok {
+		req.Timezone = timezone
+	}
+	enabled := c.IsSet("enabled")
+	req.Enabled = &enabled
+
+	if teamName, ok := getVal("team", c); ok {
+		req.OwnerTeam = &og.OwnerTeam{
+			Name: teamName,
+		}
+	}
+
+	printVerboseMessage("Create schedule request prepared, sending request to Opsgenie..")
+
+	resp, err := cli.Create(nil, &req)
+	renderResponse(c, resp, err)
+}
+
+func GetScheduleAction(c *gcli.Context) {
+	cli := NewScheduleClient(c)
+	req := schedule.GetRequest{}
+
+	req.IdentifierType = schedule.Id
+	if identifier, ok := getVal("identifierType", c); ok {
+		if identifier == "name" {
+			req.IdentifierType = schedule.Name
+		}
+	}
+	if id, ok := getVal("id", c); ok {
+		req.IdentifierValue = id
+	}
+
+	printVerboseMessage("Get schedule request prepared, sending request to Opsgenie..")
+
+	resp, err := cli.Get(nil, &req)
+
+	renderResponse(c, resp, err)
+}
+
+func ListScheduleAction(c *gcli.Context) {
+	cli := NewScheduleClient(c)
+	req := schedule.ListRequest{}
+	expand := c.IsSet("expand")
+	req.Expand = &expand
+	printVerboseMessage("List schedules request prepared, sending request to Opsgenie..")
+	resp, err := cli.List(nil, &req)
+	renderResponse(c, resp, err)
+}
+
+func UpdateScheduleAction(c *gcli.Context) {
+	cli := NewScheduleClient(c)
+	req := schedule.UpdateRequest{}
+
+	req.IdentifierType = schedule.Id
+	if identifier, ok := getVal("identifierType", c); ok {
+		if identifier == "name" {
+			req.IdentifierType = schedule.Name
+		}
+	}
+	if id, ok := getVal("id", c); ok {
+		req.IdentifierValue = id
+	}
+
+	if name, ok := getVal("name", c); ok {
+		req.Name = name
+	}
+	if description, ok := getVal("description", c); ok {
+		req.Description = description
+	}
+	if timezone, ok := getVal("tz", c); ok {
+		req.Timezone = timezone
+	}
+	enabled := c.IsSet("enabled")
+	req.Enabled = &enabled
+
+	if teamName, ok := getVal("team", c); ok {
+		req.OwnerTeam = &og.OwnerTeam{
+			Name: teamName,
+		}
+	}
+
+	printVerboseMessage("Update schedule request prepared, sending request to Opsgenie..")
+
+	resp, err := cli.Update(nil, &req)
+
+	renderResponse(c, resp, err)
+}
+
+func DeleteScheduleAction(c *gcli.Context) {
+	cli := NewScheduleClient(c)
+	req := schedule.DeleteRequest{}
+
+	req.IdentifierType = schedule.Id
+	if identifier, ok := getVal("identifierType", c); ok {
+		if identifier == "name" {
+			req.IdentifierType = schedule.Name
+		}
+	}
+	if id, ok := getVal("id", c); ok {
+		req.IdentifierValue = id
+	}
+
+	printVerboseMessage("Delete schedule request prepared, sending request to Opsgenie..")
+
+	resp, err := cli.Delete(nil, &req)
+
+	renderResponse(c, resp, err)
+}
+
+func GetScheduleTimelineAction(c *gcli.Context) {
+	cli := NewScheduleClient(c)
+	req := schedule.GetTimelineRequest{}
+
+	req.IdentifierType = schedule.Id
+	if identifier, ok := getVal("identifierType", c); ok {
+		if identifier == "name" {
+			req.IdentifierType = schedule.Name
+		}
+	}
+	if id, ok := getVal("id", c); ok {
+		req.IdentifierValue = id
+	}
+
+	if expand, ok := getVal("expand", c); ok {
+		switch expand {
+		case "base":
+			req.Expands = []schedule.ExpandType{schedule.Base}
+		case "forwarding":
+			req.Expands = []schedule.ExpandType{schedule.Forwarding}
+		case "override":
+			req.Expands = []schedule.ExpandType{schedule.Override}
+		}
+	}
+
+	req.IntervalUnit = schedule.Weeks
+
+	if intervalUnit, ok := getVal("intervalUnit", c); ok {
+		switch intervalUnit {
+		case "days":
+			req.IntervalUnit = schedule.Days
+		case "months":
+			req.IntervalUnit = schedule.Months
+		default:
+			req.IntervalUnit = schedule.Weeks
+		}
+	}
+
+	if interval, ok := getVal("interval", c); ok {
+		intervalInt, err := strconv.Atoi(interval)
+		exitOnErr(err)
+		req.Interval = intervalInt
+	}
+
+	if dateStr, ok := getVal("date", c); ok {
+		date, err := time.Parse(time.RFC3339, dateStr)
+		exitOnErr(err)
+		req.Date = &date
+	}
+
+	printVerboseMessage("Get schedule timeline request prepared, sending request to Opsgenie..")
+	resp, err := cli.GetTimeline(nil, &req)
+
+	renderResponse(c, resp, err)
+
+}
+
+func CreateScheduleRotationAction(c *gcli.Context) {
+	cli := NewScheduleClient(c)
+	req := schedule.CreateRotationRequest{}
+	rotation := og.Rotation{}
+
+	req.ScheduleIdentifierType = schedule.Id
+	if identifier, ok := getVal("identifierType", c); ok {
+		if identifier == "name" {
+			req.ScheduleIdentifierType = schedule.Name
+		}
+	}
+	if id, ok := getVal("id", c); ok {
+		req.ScheduleIdentifierValue = id
+	}
+
+	if name, ok := getVal("name", c); ok {
+		rotation.Name = name
+	}
+
+	if rotationType, ok := getVal("type", c); ok {
+		switch rotationType {
+		case "hourly":
+			rotation.Type = og.Hourly
+		case "daily":
+			rotation.Type = og.Daily
+		case "weekly":
+			rotation.Type = og.Weekly
+		}
+	}
+
+	if startDate, ok := getVal("startDate", c); ok {
+		date, err := time.Parse(time.RFC3339, startDate)
+		exitOnErr(err)
+		rotation.StartDate = &date
+	}
+
+	if endDate, ok := getVal("endDate", c); ok {
+		date, err := time.Parse(time.RFC3339, endDate)
+		exitOnErr(err)
+		rotation.EndDate = &date
+	}
+
+	if length, ok := getVal("length", c); ok {
+		length, err := strconv.ParseUint(length, 0, 32)
+		exitOnErr(err)
+		rotation.Length = uint32(length)
+	}
+
+	if participantsStr, ok := getVal("participants", c); ok {
+		participants := []og.Participant{}
+
+		for _, value := range strings.Split(participantsStr, ",") {
+			participantData := strings.Split(strings.TrimSpace(value), ":")
+
+			switch participantData[0] {
+			case "user":
+				participants = append(participants, og.Participant{
+					Type:     og.User,
+					Username: participantData[1],
+				})
+			case "team":
+				participants = append(participants, og.Participant{
+					Type: og.Team,
+					Name: participantData[1],
+				})
+			case "none":
+				participants = append(participants, og.Participant{
+					Type: og.None,
+				})
+			}
+		}
+
+		rotation.Participants = participants
+	}
+
+	req.Rotation = &rotation
+
+	printVerboseMessage("Create schedule rotations request prepared, sending request to Opsgenie..")
+
+	resp, err := cli.CreateRotation(nil, &req)
+
+	renderResponse(c, resp, err)
+}
+
+func GetScheduleRotationAction(c *gcli.Context) {
+	cli := NewScheduleClient(c)
+	req := schedule.GetRotationRequest{}
+
+	req.ScheduleIdentifierType = schedule.Id
+	if identifier, ok := getVal("identifierType", c); ok {
+		if identifier == "name" {
+			req.ScheduleIdentifierType = schedule.Name
+		}
+	}
+	if id, ok := getVal("id", c); ok {
+		req.ScheduleIdentifierValue = id
+	}
+
+	if rotationId, ok := getVal("rotation-id", c); ok {
+		req.RotationId = rotationId
+	}
+
+	printVerboseMessage("Get schedule rotation request prepared, sending request to Opsgenie..")
+
+	resp, err := cli.GetRotation(nil, &req)
+
+	renderResponse(c, resp, err)
+}
+
+func ListScheduleRotationsAction(c *gcli.Context) {
+	cli := NewScheduleClient(c)
+	req := schedule.ListRotationsRequest{}
+
+	req.ScheduleIdentifierType = schedule.Id
+	if identifier, ok := getVal("identifierType", c); ok {
+		if identifier == "name" {
+			req.ScheduleIdentifierType = schedule.Name
+		}
+	}
+	if id, ok := getVal("id", c); ok {
+		req.ScheduleIdentifierValue = id
+	}
+
+	printVerboseMessage("List schedule rotations request prepared, sending request to Opsgenie..")
+
+	resp, err := cli.ListRotations(nil, &req)
+
+	renderResponse(c, resp, err)
+}
+
+func UpdateScheduleRotationAction(c *gcli.Context) {
+	cli := NewScheduleClient(c)
+	req := schedule.UpdateRotationRequest{}
+
+	req.ScheduleIdentifierType = schedule.Id
+	if identifier, ok := getVal("identifierType", c); ok {
+		if identifier == "name" {
+			req.ScheduleIdentifierType = schedule.Name
+		}
+	}
+	if id, ok := getVal("id", c); ok {
+		req.ScheduleIdentifierValue = id
+	}
+
+	if rotationId, ok := getVal("rotation-id", c); ok {
+		req.RotationId = rotationId
+	}
+
+	rotation := og.Rotation{}
+
+	if name, ok := getVal("name", c); ok {
+		rotation.Name = name
+	}
+
+	if rotationType, ok := getVal("type", c); ok {
+		switch rotationType {
+		case "hourly":
+			rotation.Type = og.Hourly
+		case "daily":
+			rotation.Type = og.Daily
+		case "weekly":
+			rotation.Type = og.Weekly
+		}
+	}
+
+	if startDate, ok := getVal("startDate", c); ok {
+		date, err := time.Parse(time.RFC3339, startDate)
+		exitOnErr(err)
+		rotation.StartDate = &date
+	}
+
+	if endDate, ok := getVal("endDate", c); ok {
+		date, err := time.Parse(time.RFC3339, endDate)
+		exitOnErr(err)
+		rotation.EndDate = &date
+	}
+
+	if length, ok := getVal("length", c); ok {
+		length, err := strconv.ParseUint(length, 0, 32)
+		exitOnErr(err)
+		rotation.Length = uint32(length)
+	}
+
+	if participantsStr, ok := getVal("participants", c); ok {
+		participants := []og.Participant{}
+
+		for _, value := range strings.Split(participantsStr, ",") {
+			participantData := strings.Split(strings.TrimSpace(value), ":")
+
+			switch participantData[0] {
+			case "user":
+				participants = append(participants, og.Participant{
+					Type:     og.User,
+					Username: participantData[1],
+				})
+			case "team":
+				participants = append(participants, og.Participant{
+					Type: og.Team,
+					Name: participantData[1],
+				})
+			case "none":
+				participants = append(participants, og.Participant{
+					Type: og.None,
+				})
+			}
+		}
+
+		rotation.Participants = participants
+	}
+
+	req.Rotation = &rotation
+	printVerboseMessage("Update schedule rotation request prepared, sending request to Opsgenie..")
+
+	resp, err := cli.UpdateRotation(nil, &req)
+
+	renderResponse(c, resp, err)
+}
+
+func DeleteScheduleRotationAction(c *gcli.Context) {
+	cli := NewScheduleClient(c)
+	req := schedule.DeleteRotationRequest{}
+
+	req.ScheduleIdentifierType = schedule.Id
+	if identifier, ok := getVal("identifierType", c); ok {
+		if identifier == "name" {
+			req.ScheduleIdentifierType = schedule.Name
+		}
+	}
+	if id, ok := getVal("id", c); ok {
+		req.ScheduleIdentifierValue = id
+	}
+
+	if rotationId, ok := getVal("rotation-id", c); ok {
+		req.RotationId = rotationId
+	}
+
+	printVerboseMessage("Delete schedule rotation request prepared, sending request to Opsgenie..")
+
+	resp, err := cli.DeleteRotation(nil, &req)
+
+	renderResponse(c, resp, err)
+}
+
+func CreateScheduleOverrideAction(c *gcli.Context) {
+	cli := NewScheduleClient(c)
+	req := schedule.CreateScheduleOverrideRequest{}
+
+	req.ScheduleIdentifierType = schedule.Id
+	if identifier, ok := getVal("identifierType", c); ok {
+		if identifier == "name" {
+			req.ScheduleIdentifierType = schedule.Name
+		}
+	}
+	if id, ok := getVal("id", c); ok {
+		req.ScheduleIdentifier = id
+	}
+
+	if overrideAlias, ok := getVal("alias", c); ok {
+		req.Alias = overrideAlias
+	}
+
+	if startDate, ok := getVal("startDate", c); ok {
+		date, err := time.Parse(time.RFC3339, startDate)
+		exitOnErr(err)
+		req.StartDate = date
+	}
+
+	if endDate, ok := getVal("endDate", c); ok {
+		date, err := time.Parse(time.RFC3339, endDate)
+		exitOnErr(err)
+		req.EndDate = date
+	}
+
+	if responderStr, ok := getVal("responder", c); ok {
+		responderData := strings.Split(strings.TrimSpace(responderStr), ":")
+		switch responderData[0] {
+		case "user":
+			req.User = schedule.Responder{
+				Type:     schedule.UserResponderType,
+				Username: responderData[1],
+			}
+		case "team":
+			req.User = schedule.Responder{
+				Type: schedule.TeamResponderType,
+				Name: responderData[1],
+			}
+		case "escalation":
+			req.User = schedule.Responder{
+				Type: schedule.EscalationResponderType,
+				Name: responderData[1],
+			}
+		}
+	}
+
+	if rotationsStr, ok := getVal("rotations", c); ok {
+		rotations := []schedule.RotationIdentifier{}
+		for _, rotationId := range strings.Split(rotationsStr, ",") {
+			rotations = append(rotations, schedule.RotationIdentifier{Id: rotationId})
+		}
+		req.Rotations = rotations
+	}
+	printVerboseMessage("Create schedule override request prepared, sending request to Opsgenie..")
+
+	resp, err := cli.CreateScheduleOverride(nil, &req)
+
+	renderResponse(c, resp, err)
+}
+
+func ListScheduleOverridesAction(c *gcli.Context) {
+	cli := NewScheduleClient(c)
+	req := schedule.ListScheduleOverrideRequest{}
+
+	req.ScheduleIdentifierType = schedule.Id
+	if identifier, ok := getVal("identifierType", c); ok {
+		if identifier == "name" {
+			req.ScheduleIdentifierType = schedule.Name
+		}
+	}
+	if id, ok := getVal("id", c); ok {
+		req.ScheduleIdentifier = id
+	}
+
+	printVerboseMessage("List schedule overrides request prepared, sending request to Opsgenie..")
+
+	resp, err := cli.ListScheduleOverride(nil, &req)
+
+	renderResponse(c, resp, err)
+}
+
+func GetScheduleOverrideAction(c *gcli.Context) {
+	cli := NewScheduleClient(c)
+	req := schedule.GetScheduleOverrideRequest{}
+
+	req.ScheduleIdentifierType = schedule.Id
+	if identifier, ok := getVal("identifierType", c); ok {
+		if identifier == "name" {
+			req.ScheduleIdentifierType = schedule.Name
+		}
+	}
+	if id, ok := getVal("id", c); ok {
+		req.ScheduleIdentifier = id
+	}
+
+	if overrideAlias, ok := getVal("alias", c); ok {
+		req.Alias = overrideAlias
+	}
+	printVerboseMessage("Get schedule override request prepared, sending request to Opsgenie..")
+
+	resp, err := cli.GetScheduleOverride(nil, &req)
+
+	renderResponse(c, resp, err)
+}
+
+func UpdateScheduleOverrideAction(c *gcli.Context) {
+	cli := NewScheduleClient(c)
+	req := schedule.UpdateScheduleOverrideRequest{}
+
+	req.ScheduleIdentifierType = schedule.Id
+	if identifier, ok := getVal("identifierType", c); ok {
+		if identifier == "name" {
+			req.ScheduleIdentifierType = schedule.Name
+		}
+	}
+	if id, ok := getVal("id", c); ok {
+		req.ScheduleIdentifier = id
+	}
+
+	if overrideAlias, ok := getVal("alias", c); ok {
+		req.Alias = overrideAlias
+	}
+
+	if startDate, ok := getVal("startDate", c); ok {
+		date, err := time.Parse(time.RFC3339, startDate)
+		exitOnErr(err)
+		req.StartDate = date
+	}
+
+	if endDate, ok := getVal("endDate", c); ok {
+		date, err := time.Parse(time.RFC3339, endDate)
+		exitOnErr(err)
+		req.EndDate = date
+	}
+
+	if responderStr, ok := getVal("responder", c); ok {
+		responderData := strings.Split(strings.TrimSpace(responderStr), ":")
+		switch responderData[0] {
+		case "user":
+			req.User = schedule.Responder{
+				Type:     schedule.UserResponderType,
+				Username: responderData[1],
+			}
+		case "team":
+			req.User = schedule.Responder{
+				Type: schedule.TeamResponderType,
+				Name: responderData[1],
+			}
+		case "escalation":
+			req.User = schedule.Responder{
+				Type: schedule.EscalationResponderType,
+				Name: responderData[1],
+			}
+		}
+	}
+
+	if rotationsStr, ok := getVal("rotations", c); ok {
+		rotations := []schedule.RotationIdentifier{}
+		for _, rotationId := range strings.Split(rotationsStr, ",") {
+			rotations = append(rotations, schedule.RotationIdentifier{Id: rotationId})
+		}
+		req.Rotations = rotations
+	}
+
+	printVerboseMessage("Update schedule override request prepared, sending request to Opsgenie..")
+
+	resp, err := cli.UpdateScheduleOverride(nil, &req)
+
+	renderResponse(c, resp, err)
+}
+
+func DeleteScheduleOverrideAction(c *gcli.Context) {
+	cli := NewScheduleClient(c)
+	req := schedule.DeleteScheduleOverrideRequest{}
+
+	req.ScheduleIdentifierType = schedule.Id
+	if identifier, ok := getVal("identifierType", c); ok {
+		if identifier == "name" {
+			req.ScheduleIdentifierType = schedule.Name
+		}
+	}
+	if id, ok := getVal("id", c); ok {
+		req.ScheduleIdentifier = id
+	}
+
+	if overrideAlias, ok := getVal("alias", c); ok {
+		req.Alias = overrideAlias
+	}
+	printVerboseMessage("Delete schedule override request prepared, sending request to Opsgenie..")
+
+	resp, err := cli.DeleteScheduleOverride(nil, &req)
+
+	renderResponse(c, resp, err)
+}
+
+func exitOnErr(err error) {
+	if err != nil {
+		fmt.Printf("%s\n", err.Error())
+		os.Exit(1)
+	}
+}
+
+func renderResponse(c *gcli.Context, resp interface{}, err error) {
+	exitOnErr(err)
+
+	outputFormat := strings.ToLower(c.String("output-format"))
+	printVerboseMessage("Got response successfully, rendering in " + outputFormat + " format")
+
+	switch outputFormat {
+	case "yaml":
+		output, err := resultToYAML(resp)
+		exitOnErr(err)
+		fmt.Printf("%s\n", output)
+	default:
+		isPretty := c.IsSet("pretty")
+		output, err := resultToJSON(resp, isPretty)
+		exitOnErr(err)
+		fmt.Printf("%s\n", output)
+	}
+}

--- a/lamp.go
+++ b/lamp.go
@@ -1268,8 +1268,8 @@ func UpdateEscalationCommand() gcli.Command {
 func createTeamCommand() gcli.Command {
 	commandFlags := []gcli.Flag{
 		gcli.StringFlag{
-			Name:  "name, n",
-			Usage: "Team Name",
+			Name:     "name, n",
+			Usage:    "Team Name",
 			Required: true,
 		},
 		gcli.StringFlag{
@@ -1549,7 +1549,6 @@ func deleteTeamRoutingRulesCommand() gcli.Command {
 	return cmd
 }
 
-
 func createRoleCommand() gcli.Command {
 	commandFlags := []gcli.Flag{
 		gcli.StringFlag{
@@ -1561,13 +1560,13 @@ func createRoleCommand() gcli.Command {
 			Usage: "Team Id",
 		},
 		gcli.StringFlag{
-			Name:  "roleName",
-			Usage: "Role Name",
+			Name:     "roleName",
+			Usage:    "Role Name",
 			Required: true,
 		},
 		gcli.StringFlag{
-			Name:  "rights",
-			Usage: "Role rights",
+			Name:     "rights",
+			Usage:    "Role rights",
 			Required: true,
 		},
 		gcli.BoolFlag{
@@ -1788,6 +1787,526 @@ func getRoutingRuleCommand() gcli.Command {
 	return cmd
 }
 
+func createScheduleCommand() gcli.Command {
+	commandFlags := append([]gcli.Flag{
+		gcli.StringFlag{
+			Name:  "name, n",
+			Usage: "Name of the schedule to be created",
+		},
+		gcli.StringFlag{
+			Name:  "description",
+			Usage: "Description of the schedule to be created",
+		},
+		gcli.StringFlag{
+			Name:  "tz",
+			Usage: "Timezone for the schedule",
+		},
+		gcli.StringFlag{
+			Name:  "team",
+			Usage: "Name of the team under which the schedule is",
+		},
+		gcli.BoolFlag{
+			Name:  "enabled",
+			Usage: "Enable the created schedule",
+		},
+	}, renderingFlags...)
+	flags := append(commonFlags, commandFlags...)
+	cmd := gcli.Command{Name: "createSchedule",
+		Flags: flags,
+		Usage: "Creates a schedule on Opsgenie",
+		Action: func(c *gcli.Context) error {
+			command.CreateScheduleAction(c)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func getScheduleCommand() gcli.Command {
+	commandFlags := append([]gcli.Flag{
+		gcli.StringFlag{
+			Name:  "id",
+			Usage: "ID of the schedule",
+		},
+		gcli.StringFlag{
+			Name:  "identifierType",
+			Usage: "Identifier type of the specified schedule id, which can be id, name. Default value = id",
+		},
+	}, renderingFlags...)
+	flags := append(commonFlags, commandFlags...)
+	cmd := gcli.Command{Name: "getSchedule",
+		Flags: flags,
+		Usage: "Gets a schedule's content from Opsgenie",
+		Action: func(c *gcli.Context) error {
+			command.GetScheduleAction(c)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func updateScheduleCommand() gcli.Command {
+	commandFlags := append([]gcli.Flag{
+		gcli.StringFlag{
+			Name:  "id",
+			Usage: "ID of the schedule",
+		},
+		gcli.StringFlag{
+			Name:  "identifierType",
+			Usage: "Identifier type of the specified schedule id, which can be id, name. Default value = id",
+		},
+		gcli.StringFlag{
+			Name:  "name",
+			Usage: "Name of the schedule",
+		},
+		gcli.StringFlag{
+			Name:  "description",
+			Usage: "Description of the schedule to be created",
+		},
+		gcli.StringFlag{
+			Name:  "tz",
+			Usage: "Timezone for the schedule",
+		},
+		gcli.StringFlag{
+			Name:  "team",
+			Usage: "Name of the team under which the schedule is",
+		},
+		gcli.BoolFlag{
+			Name:  "enabled",
+			Usage: "Enable the schedule",
+		},
+	}, renderingFlags...)
+	flags := append(commonFlags, commandFlags...)
+	cmd := gcli.Command{Name: "updateSchedule",
+		Flags: flags,
+		Usage: "Updates a schedule on Opsgenie",
+		Action: func(c *gcli.Context) error {
+			command.UpdateScheduleAction(c)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func deleteScheduleCommand() gcli.Command {
+	commandFlags := append([]gcli.Flag{
+		gcli.StringFlag{
+			Name:  "id",
+			Usage: "ID of the schedule",
+		},
+		gcli.StringFlag{
+			Name:  "identifierType",
+			Usage: "Identifier type of the specified schedule id, which can be id, name. Default value = id",
+		},
+	}, renderingFlags...)
+	flags := append(commonFlags, commandFlags...)
+	cmd := gcli.Command{Name: "deleteSchedule",
+		Flags: flags,
+		Usage: "Delete a schedule's content from Opsgenie",
+		Action: func(c *gcli.Context) error {
+			command.DeleteScheduleAction(c)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func listSchedulesCommand() gcli.Command {
+	commandFlags := append([]gcli.Flag{
+		gcli.BoolFlag{
+			Name:  "expand",
+			Usage: "Get more detailed response by expanding it",
+		},
+	}, renderingFlags...)
+	flags := append(commonFlags, commandFlags...)
+	cmd := gcli.Command{Name: "listSchedules",
+		Flags: flags,
+		Usage: "List schedules in Opsgenie",
+		Action: func(c *gcli.Context) error {
+			command.ListScheduleAction(c)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func getScheduleTimelineCommand() gcli.Command {
+	commandFlags := append([]gcli.Flag{
+		gcli.StringFlag{
+			Name:  "id",
+			Usage: "ID of the schedule",
+		},
+		gcli.StringFlag{
+			Name:  "identifierType",
+			Usage: "Identifier type of the specified schedule id, which can be id, name. Default value = id",
+		},
+		gcli.StringFlag{
+			Name:  "interval",
+			Usage: "Length of time as integer in intervalUnits",
+		},
+		gcli.StringFlag{
+			Name:  "intervalUnit",
+			Usage: "Unit of the time to retrieve the timeline. Possible values: days, weeks and months",
+		},
+		gcli.StringFlag{
+			Name:  "expand",
+			Usage: "Get a detailed response. Possible values: base, forwarding, override",
+		},
+		gcli.StringFlag{
+			Name:  "date",
+			Usage: "Time (in ISO8601) to return future date on-call participants. Default is now",
+		},
+	}, renderingFlags...)
+
+	flags := append(commonFlags, commandFlags...)
+	cmd := gcli.Command{Name: "getScheduleTimeline",
+		Flags: flags,
+		Usage: "Get the timeline of the given schedule",
+		Action: func(c *gcli.Context) error {
+			command.GetScheduleTimelineAction(c)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func createScheduleRotationCommand() gcli.Command {
+	commandFlags := append([]gcli.Flag{
+		gcli.StringFlag{
+			Name:  "id",
+			Usage: "ID of the schedule",
+		},
+		gcli.StringFlag{
+			Name:  "identifierType",
+			Usage: "Identifier type of the specified schedule id, which can be id, name. Default value = id",
+		},
+		gcli.StringFlag{
+			Name:  "startDate",
+			Usage: "Schedule Start Date in ISO8601 format",
+		},
+		gcli.StringFlag{
+			Name:  "endDate",
+			Usage: "Schedule End Date in ISO8601 format",
+		},
+		gcli.StringFlag{
+			Name:  "type",
+			Usage: "Type of rotation. Available values: daily, weekly and hourly",
+		},
+		gcli.StringFlag{
+			Name:  "name",
+			Usage: "Name of the rotation",
+		},
+		gcli.StringFlag{
+			Name:  "participants",
+			Usage: "A comma separated list of participants. Example: user:<user-email>, team:<team-name>, none",
+		},
+		gcli.StringFlag{
+			Name:  "length",
+			Usage: "Length of the rotation. Default: 1",
+		},
+	}, renderingFlags...)
+	flags := append(commonFlags, commandFlags...)
+	cmd := gcli.Command{Name: "createScheduleRotation",
+		Flags: flags,
+		Usage: "List the rotations for a schedule",
+		Action: func(c *gcli.Context) error {
+			command.CreateScheduleRotationAction(c)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func getScheduleRotationCommand() gcli.Command {
+	commandFlags := append([]gcli.Flag{
+		gcli.StringFlag{
+			Name:  "id",
+			Usage: "ID of the schedule",
+		},
+		gcli.StringFlag{
+			Name:  "identifierType",
+			Usage: "Identifier type of the specified schedule id, which can be id, name. Default value = id",
+		},
+		gcli.StringFlag{
+			Name:  "rotation-id",
+			Usage: "ID of the rotation",
+		},
+	}, renderingFlags...)
+	flags := append(commonFlags, commandFlags...)
+	cmd := gcli.Command{Name: "getScheduleRotation",
+		Flags: flags,
+		Usage: "Get a rotation from the schedule",
+		Action: func(c *gcli.Context) error {
+			command.GetScheduleRotationAction(c)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func listScheduleRotationsCommand() gcli.Command {
+	commandFlags := append([]gcli.Flag{
+		gcli.StringFlag{
+			Name:  "id",
+			Usage: "ID of the schedule",
+		},
+		gcli.StringFlag{
+			Name:  "identifierType",
+			Usage: "Identifier type of the specified schedule id, which can be id, name. Default value = id",
+		},
+	}, renderingFlags...)
+	flags := append(commonFlags, commandFlags...)
+	cmd := gcli.Command{Name: "listScheduleRotations",
+		Flags: flags,
+		Usage: "List the rotations for a schedule",
+		Action: func(c *gcli.Context) error {
+			command.ListScheduleRotationsAction(c)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func updateScheduleRotationCommand() gcli.Command {
+	commandFlags := append([]gcli.Flag{
+		gcli.StringFlag{
+			Name:  "id",
+			Usage: "ID of the schedule",
+		},
+		gcli.StringFlag{
+			Name:  "identifierType",
+			Usage: "Identifier type of the specified schedule id, which can be id, name. Default value = id",
+		},
+		gcli.StringFlag{
+			Name:  "rotation-id",
+			Usage: "ID of the rotation",
+		},
+		gcli.StringFlag{
+			Name:  "name",
+			Usage: "Name of the rotation",
+		},
+		gcli.StringFlag{
+			Name:  "startDate",
+			Usage: "Schedule Start Date in ISO8601 format",
+		},
+		gcli.StringFlag{
+			Name:  "endDate",
+			Usage: "Schedule End Date in ISO8601 format",
+		},
+		gcli.StringFlag{
+			Name:  "type",
+			Usage: "Type of rotation. Available values: daily, weekly and hourly",
+		},
+		gcli.StringFlag{
+			Name:  "participants",
+			Usage: "A comma separated list of participants. Example: user:<user-email>, team:<team-name>, none",
+		},
+		gcli.StringFlag{
+			Name:  "length",
+			Usage: "Length of the rotation. Default: 1",
+		},
+	}, renderingFlags...)
+	flags := append(commonFlags, commandFlags...)
+	cmd := gcli.Command{Name: "updateScheduleRotation",
+		Flags: flags,
+		Usage: "Update a rotation from the schedule",
+		Action: func(c *gcli.Context) error {
+			command.UpdateScheduleRotationAction(c)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func deleteScheduleRotationCommand() gcli.Command {
+	commandFlags := append([]gcli.Flag{
+		gcli.StringFlag{
+			Name:  "id",
+			Usage: "ID of the schedule",
+		},
+		gcli.StringFlag{
+			Name:  "identifierType",
+			Usage: "Identifier type of the specified schedule id, which can be id, name. Default value = id",
+		},
+		gcli.StringFlag{
+			Name:  "rotation-id",
+			Usage: "ID of the rotation",
+		},
+	}, renderingFlags...)
+	flags := append(commonFlags, commandFlags...)
+	cmd := gcli.Command{Name: "deleteScheduleRotation",
+		Flags: flags,
+		Usage: "Delete a rotation from the schedule",
+		Action: func(c *gcli.Context) error {
+			command.DeleteScheduleRotationAction(c)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func createScheduleOverrideCommand() gcli.Command {
+	commandFlags := append([]gcli.Flag{
+		gcli.StringFlag{
+			Name:  "id",
+			Usage: "ID of the schedule",
+		},
+		gcli.StringFlag{
+			Name:  "identifierType",
+			Usage: "Identifier type of the specified schedule id, which can be id, name. Default value = id",
+		},
+		gcli.StringFlag{
+			Name:  "alias",
+			Usage: "Alias of the schedule override",
+		},
+		gcli.StringFlag{
+			Name:  "startDate",
+			Usage: "Schedule override Start Date in ISO8601 format",
+		},
+		gcli.StringFlag{
+			Name:  "endDate",
+			Usage: "Schedule override End Date in ISO8601 format",
+		},
+		gcli.StringFlag{
+			Name:  "responder",
+			Usage: "Responder type and name. Examples: user:<user-email>, team:<team-name>, escalation:<escalation-name>",
+		},
+		gcli.StringFlag{
+			Name:  "rotations",
+			Usage: "Comma separated list of rotation ids",
+		},
+	}, renderingFlags...)
+	flags := append(commonFlags, commandFlags...)
+	cmd := gcli.Command{Name: "createScheduleOverride",
+		Flags: flags,
+		Usage: "Create a schedule override",
+		Action: func(c *gcli.Context) error {
+			command.CreateScheduleOverrideAction(c)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func listScheduleOverridesCommand() gcli.Command {
+	commandFlags := append([]gcli.Flag{
+		gcli.StringFlag{
+			Name:  "id",
+			Usage: "ID of the schedule",
+		},
+		gcli.StringFlag{
+			Name:  "identifierType",
+			Usage: "Identifier type of the specified schedule id, which can be id, name. Default value = id",
+		},
+	}, renderingFlags...)
+	flags := append(commonFlags, commandFlags...)
+	cmd := gcli.Command{Name: "listScheduleOverrides",
+		Flags: flags,
+		Usage: "List the overrides for a schedule",
+		Action: func(c *gcli.Context) error {
+			command.ListScheduleOverridesAction(c)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func getScheduleOverrideCommand() gcli.Command {
+	commandFlags := append([]gcli.Flag{
+		gcli.StringFlag{
+			Name:  "id",
+			Usage: "ID of the schedule",
+		},
+		gcli.StringFlag{
+			Name:  "identifierType",
+			Usage: "Identifier type of the specified schedule id, which can be id, name. Default value = id",
+		},
+		gcli.StringFlag{
+			Name:  "alias",
+			Usage: "Alias of the schedule override",
+		},
+	}, renderingFlags...)
+	flags := append(commonFlags, commandFlags...)
+	cmd := gcli.Command{Name: "getScheduleOverride",
+		Flags: flags,
+		Usage: "Get details for a schedule override",
+		Action: func(c *gcli.Context) error {
+			command.GetScheduleOverrideAction(c)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func updateScheduleOverrideCommand() gcli.Command {
+	commandFlags := append([]gcli.Flag{
+		gcli.StringFlag{
+			Name:  "id",
+			Usage: "ID of the schedule",
+		},
+		gcli.StringFlag{
+			Name:  "identifierType",
+			Usage: "Identifier type of the specified schedule id, which can be id, name. Default value = id",
+		},
+		gcli.StringFlag{
+			Name:  "alias",
+			Usage: "Alias of the schedule override",
+		},
+		gcli.StringFlag{
+			Name:  "startDate",
+			Usage: "Schedule override Start Date in ISO8601 format",
+		},
+		gcli.StringFlag{
+			Name:  "endDate",
+			Usage: "Schedule override End Date in ISO8601 format",
+		},
+		gcli.StringFlag{
+			Name:  "responder",
+			Usage: "Responder type and name. Examples: user:<user-email>, team:<team-name>, escalation:<escalation-name>",
+		},
+		gcli.StringFlag{
+			Name:  "rotations",
+			Usage: "Comma separated list of rotation ids",
+		},
+	}, renderingFlags...)
+	flags := append(commonFlags, commandFlags...)
+	cmd := gcli.Command{Name: "updateScheduleOverride",
+		Flags: flags,
+		Usage: "Update a schedule override.",
+		Action: func(c *gcli.Context) error {
+			command.UpdateScheduleOverrideAction(c)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func deleteScheduleOverrideCommand() gcli.Command {
+	commandFlags := append([]gcli.Flag{
+		gcli.StringFlag{
+			Name:  "id",
+			Usage: "ID of the schedule",
+		},
+		gcli.StringFlag{
+			Name:  "identifierType",
+			Usage: "Identifier type of the specified schedule id, which can be id, name. Default value = id",
+		},
+		gcli.StringFlag{
+			Name:  "alias",
+			Usage: "Alias of the schedule override",
+		},
+	}, renderingFlags...)
+	flags := append(commonFlags, commandFlags...)
+	cmd := gcli.Command{Name: "deleteScheduleOverride",
+		Flags: flags,
+		Usage: "Delete a schedule override.",
+		Action: func(c *gcli.Context) error {
+			command.DeleteScheduleOverrideAction(c)
+			return nil
+		},
+	}
+	return cmd
+}
 
 func initCommands(app *gcli.App) {
 	app.Commands = []gcli.Command{
@@ -1843,6 +2362,22 @@ func initCommands(app *gcli.App) {
 		fetchEscalationCommand(),
 		deleteEscalationCommand(),
 		UpdateEscalationCommand(),
+		createScheduleCommand(),
+		getScheduleCommand(),
+		listSchedulesCommand(),
+		updateScheduleCommand(),
+		deleteScheduleCommand(),
+		getScheduleTimelineCommand(),
+		createScheduleRotationCommand(),
+		getScheduleRotationCommand(),
+		listScheduleRotationsCommand(),
+		updateScheduleRotationCommand(),
+		deleteScheduleRotationCommand(),
+		createScheduleOverrideCommand(),
+		listScheduleOverridesCommand(),
+		getScheduleOverrideCommand(),
+		updateScheduleOverrideCommand(),
+		deleteScheduleOverrideCommand(),
 	}
 }
 


### PR DESCRIPTION
Command: `createSchedule`
```
NAME:
   opsgenie-lamp createSchedule - Creates a schedule on Opsgenie

USAGE:
   opsgenie-lamp createSchedule [command options] [arguments...]

OPTIONS:
   -v                      Execute commands in verbose mode
   --apiKey value          API key used for authenticating API requests. If not given, the api key in the conf file is used
   --user value            Owner of the execution
   --config value          Configuration file path
   --name value, -n value  Name of the schedule to be created
   --description value     Description of the schedule to be created
   --tz value              Timezone for the schedule
   --team value            Name of the team under which the schedule is
   --enabled               Enable the created schedule
   --output-format value   Prints the output in json or yaml formats (default: "json")
   --pretty                For more readable JSON output
   
```
Command: `getSchedule`
```
NAME:
   opsgenie-lamp getSchedule - Gets a schedule's content from Opsgenie

USAGE:
   opsgenie-lamp getSchedule [command options] [arguments...]

OPTIONS:
   -v                     Execute commands in verbose mode
   --apiKey value         API key used for authenticating API requests. If not given, the api key in the conf file is used
   --user value           Owner of the execution
   --config value         Configuration file path
   --id value             ID of the schedule
   --identifier value     Identifier type of the specified schedule id, which can be id, name. Default value = id
   --output-format value  Prints the output in json or yaml formats (default: "json")
   --pretty               For more readable JSON output
   
```
Command: `listSchedules`
```
NAME:
   opsgenie-lamp listSchedules - List schedules in Opsgenie

USAGE:
   opsgenie-lamp listSchedules [command options] [arguments...]

OPTIONS:
   -v                     Execute commands in verbose mode
   --apiKey value         API key used for authenticating API requests. If not given, the api key in the conf file is used
   --user value           Owner of the execution
   --config value         Configuration file path
   --expand               Get more detailed response by expanding it
   --output-format value  Prints the output in json or yaml formats (default: "json")
   --pretty               For more readable JSON output
   
```
Command: `updateSchedule`
```
NAME:
   opsgenie-lamp updateSchedule - Updates a schedule on Opsgenie

USAGE:
   opsgenie-lamp updateSchedule [command options] [arguments...]

OPTIONS:
   -v                     Execute commands in verbose mode
   --apiKey value         API key used for authenticating API requests. If not given, the api key in the conf file is used
   --user value           Owner of the execution
   --config value         Configuration file path
   --id value             ID of the schedule
   --identifier value     Identifier type of the specified schedule id, which can be id, name. Default value = id
   --name value           Name of the schedule
   --description value    Description of the schedule to be created
   --tz value             Timezone for the schedule
   --team value           Name of the team under which the schedule is
   --enabled              Enable the schedule
   --output-format value  Prints the output in json or yaml formats (default: "json")
   --pretty               For more readable JSON output
   
```
Command: `deleteSchedule`
```
NAME:
   opsgenie-lamp deleteSchedule - Delete a schedule's content from Opsgenie

USAGE:
   opsgenie-lamp deleteSchedule [command options] [arguments...]

OPTIONS:
   -v                     Execute commands in verbose mode
   --apiKey value         API key used for authenticating API requests. If not given, the api key in the conf file is used
   --user value           Owner of the execution
   --config value         Configuration file path
   --id value             ID of the schedule
   --identifier value     Identifier type of the specified schedule id, which can be id, name. Default value = id
   --output-format value  Prints the output in json or yaml formats (default: "json")
   --pretty               For more readable JSON output
   
```
Command: `getScheduleTimeline`
```
NAME:
   opsgenie-lamp getScheduleTimeline - Get the timeline of the given schedule

USAGE:
   opsgenie-lamp getScheduleTimeline [command options] [arguments...]

OPTIONS:
   -v                     Execute commands in verbose mode
   --apiKey value         API key used for authenticating API requests. If not given, the api key in the conf file is used
   --user value           Owner of the execution
   --config value         Configuration file path
   --id value             ID of the schedule
   --identifier value     Identifier type of the specified schedule id, which can be id, name. Default value = id
   --interval value       Length of time as integer in intervalUnits
   --intervalUnit value   Unit of the time to retrieve the timeline. Possible values: days, weeks and months
   --expand value         Get a detailed response. Possible values: base, forwarding, override
   --date value           Time (in ISO8601) to return future date on-call participants. Default is now
   --output-format value  Prints the output in json or yaml formats (default: "json")
   --pretty               For more readable JSON output
   
```
Command: `createScheduleRotation`
```
NAME:
   opsgenie-lamp createScheduleRotation - List the rotations for a schedule

USAGE:
   opsgenie-lamp createScheduleRotation [command options] [arguments...]

OPTIONS:
   -v                     Execute commands in verbose mode
   --apiKey value         API key used for authenticating API requests. If not given, the api key in the conf file is used
   --user value           Owner of the execution
   --config value         Configuration file path
   --id value             ID of the schedule
   --identifier value     Identifier type of the specified schedule id, which can be id, name. Default value = id
   --startDate value      Schedule Start Date in ISO8601 format
   --endDate value        Schedule End Date in ISO8601 format
   --type value           Type of rotation. Available values: daily, weekly and hourly
   --name value           Name of the rotation
   --participants value   A comma separated list of participants. Example: user:<user-email>, team:<team-name>, none
   --length value         Length of the rotation. Default: 1
   --output-format value  Prints the output in json or yaml formats (default: "json")
   --pretty               For more readable JSON output
   
```
Command: `listScheduleRotations`
```
NAME:
   opsgenie-lamp listScheduleRotations - List the rotations for a schedule

USAGE:
   opsgenie-lamp listScheduleRotations [command options] [arguments...]

OPTIONS:
   -v                     Execute commands in verbose mode
   --apiKey value         API key used for authenticating API requests. If not given, the api key in the conf file is used
   --user value           Owner of the execution
   --config value         Configuration file path
   --id value             ID of the schedule
   --identifier value     Identifier type of the specified schedule id, which can be id, name. Default value = id
   --output-format value  Prints the output in json or yaml formats (default: "json")
   --pretty               For more readable JSON output
   
```
Command: `deleteScheduleRotation`
```
NAME:
   opsgenie-lamp deleteScheduleRotation - Delete a rotation from the schedule

USAGE:
   opsgenie-lamp deleteScheduleRotation [command options] [arguments...]

OPTIONS:
   -v                     Execute commands in verbose mode
   --apiKey value         API key used for authenticating API requests. If not given, the api key in the conf file is used
   --user value           Owner of the execution
   --config value         Configuration file path
   --id value             ID of the schedule
   --identifier value     Identifier type of the specified schedule id, which can be id, name. Default value = id
   --rotation-id value    ID of the rotation
   --output-format value  Prints the output in json or yaml formats (default: "json")
   --pretty               For more readable JSON output
   
```
Command: `createScheduleOverride`
```
NAME:
   opsgenie-lamp createScheduleOverride - Create a schedule override

USAGE:
   opsgenie-lamp createScheduleOverride [command options] [arguments...]

OPTIONS:
   -v                     Execute commands in verbose mode
   --apiKey value         API key used for authenticating API requests. If not given, the api key in the conf file is used
   --user value           Owner of the execution
   --config value         Configuration file path
   --id value             ID of the schedule
   --identifier value     Identifier type of the specified schedule id, which can be id, name. Default value = id
   --alias value          Alias of the schedule override
   --startDate value      Schedule override Start Date in ISO8601 format
   --endDate value        Schedule override End Date in ISO8601 format
   --responder value      Responder type and name. Examples: user:<user-email>, team:<team-name>, escalation:<escalation-name>
   --rotations value      Comma separated list of rotation ids
   --output-format value  Prints the output in json or yaml formats (default: "json")
   --pretty               For more readable JSON output
   
```
Command: `listScheduleOverrides`
```
NAME:
   opsgenie-lamp listScheduleOverrides - List the overrides for a schedule

USAGE:
   opsgenie-lamp listScheduleOverrides [command options] [arguments...]

OPTIONS:
   -v                     Execute commands in verbose mode
   --apiKey value         API key used for authenticating API requests. If not given, the api key in the conf file is used
   --user value           Owner of the execution
   --config value         Configuration file path
   --id value             ID of the schedule
   --identifier value     Identifier type of the specified schedule id, which can be id, name. Default value = id
   --output-format value  Prints the output in json or yaml formats (default: "json")
   --pretty               For more readable JSON output
   
```
Command: `getScheduleOverride`
```
NAME:
   opsgenie-lamp getScheduleOverride - Get details for a schedule override

USAGE:
   opsgenie-lamp getScheduleOverride [command options] [arguments...]

OPTIONS:
   -v                     Execute commands in verbose mode
   --apiKey value         API key used for authenticating API requests. If not given, the api key in the conf file is used
   --user value           Owner of the execution
   --config value         Configuration file path
   --id value             ID of the schedule
   --identifier value     Identifier type of the specified schedule id, which can be id, name. Default value = id
   --alias value          Alias of the schedule override
   --output-format value  Prints the output in json or yaml formats (default: "json")
   --pretty               For more readable JSON output
   
```
Command: `deleteScheduleOverride`
```
NAME:
   opsgenie-lamp deleteScheduleOverride - Delet a schedule override.

USAGE:
   opsgenie-lamp deleteScheduleOverride [command options] [arguments...]

OPTIONS:
   -v                     Execute commands in verbose mode
   --apiKey value         API key used for authenticating API requests. If not given, the api key in the conf file is used
   --user value           Owner of the execution
   --config value         Configuration file path
   --id value             ID of the schedule
   --identifier value     Identifier type of the specified schedule id, which can be id, name. Default value = id
   --alias value          Alias of the schedule override
   --output-format value  Prints the output in json or yaml formats (default: "json")
   --pretty               For more readable JSON output
   
```
