### PR TITLE
Set a value for ListLogFilesRequest.Limit 

### DIFF
--- a/command/log_cmd.go
+++ b/command/log_cmd.go
@@ -32,6 +32,7 @@ func DownloadLogs(c *gcli.Context) {
 	req := logs.ListLogFilesRequest{}
 	if val, success := getVal("start", c); success {
 		req.Marker = val
+		req.Limit = 1000
 	}
 
 	filePath := "."


### PR DESCRIPTION
This fixes a soft failure in the downloadLogs command:

`opsgenie-lamp downloadLogs --start="2021-03-09-00-00-00" --end="2021-03-13-00-00-00" -v`

returns

```
DEBU[2021-03-18T13:13:31.700337-04:00] Starting to process Request &{BaseRequest:{} Marker:2021-03-09-00-00-00 Limit:0}: to send: /v2/logs/list/2021-03-09-00-00-00
DEBU[2021-03-18T13:13:32.081995-04:00] Request processed. The result: &{ResultMetadata:{RequestId: XXXX-XXXX-XXXXX ResponseTime:0.037 RateLimitState:OK RateLimitReason: RateLimitPeriod: RetryCount:0} Logs:[] Marker:}
```

It looks like Limit=0 is implicitly assigned and inserted into the ListLogFilesRequest. `ListLogFilesRequest.Limit` is initialized/evaluated but never assigned a value:
https://github.com/opsgenie/opsgenie-go-sdk-v2/blob/adf7a1c79aac73c5b92cc7556061e8ea87828e47/logs/request.go#L37


Since `--limit` is not configurable for the `downloadLogs` command, this PR assigns the maximum value from https://docs.opsgenie.com/docs/logs-api#list-log-files

Command output with this PR showing Limit being applied to the request:
```
INFO[2021-03-18T13:41:54.918084-04:00] Client is configured with ApiUrl: api.opsgenie.com, LogLevel: debug, RetryMaxCount: 4 
DEBU[2021-03-18T13:41:54.918148-04:00] Starting to process Request &{BaseRequest:{} Marker:2021-03-09-00-00-00 Limit:1000}:
```