### PR TITLE
Adding Default Limit Value to Download Logs

### DIFF
--- a/cfg/lamp_command_config.go
+++ b/cfg/lamp_command_config.go
@@ -1,0 +1,9 @@
+package cfg
+
+const (
+	listLogCommandDefaultBucketSize int = 1000
+)
+
+func GetlistLogCommandDefaultBucketSize() int {
+	return listLogCommandDefaultBucketSize
+}

--- a/command/command.go
+++ b/command/command.go
@@ -234,3 +234,8 @@ func readConfigFile(c *gcli.Context) {
 		cfg.LoadConfiguration()
 	}
 }
+
+func getListLogsCommandDefaultSize() int{
+	return cfg.GetlistLogCommandDefaultBucketSize()
+}
+

--- a/command/log_cmd.go
+++ b/command/log_cmd.go
@@ -42,6 +42,8 @@ func DownloadLogs(c *gcli.Context) {
 		printMessage(DEBUG,"Downloading log files into current directory..")
 	}
 
+	req.Limit = getListLogsCommandDefaultSize()
+
 	endDate := ""
 	if val, success := getVal("end", c); success {
 		endDate = val


### PR DESCRIPTION
Earlier since we were not sending Limit to go-sdk it was automatically sending it to 0. Hence no logs were getting downloaded. Hence we have added default limit of 1000 (same as rest api)